### PR TITLE
Use terse guard clause for git clone

### DIFF
--- a/infra/build/run.sh
+++ b/infra/build/run.sh
@@ -19,9 +19,7 @@ declare -r _GIT_REPO='git@github.com:ScottG489/unified-diff-parser.git'
 declare -r _RUN_TASK=$(jq -r .RUN_TASK <<< "$1")
 declare -r _GIT_BRANCH=$(jq -r .GIT_BRANCH <<< "$1")
 
-if [ ! -d "$_PROJECT_NAME" ]; then
-  git clone --branch $_GIT_BRANCH $_GIT_REPO
-fi
+[ -d "$_PROJECT_NAME" ] || git clone --branch $_GIT_BRANCH $_GIT_REPO
 cd $_PROJECT_NAME
 
 build_test


### PR DESCRIPTION
## Summary
- Replace verbose if statement with concise test operator syntax for git clone guard clause
- Makes the code more terse and consistent with other projects (e.g., regex-directed-graph-line-parser)

## Changes
```bash
# Before
if [ ! -d "$_PROJECT_NAME" ]; then
  git clone --branch $_GIT_BRANCH $_GIT_REPO
fi

# After
[ -d "$_PROJECT_NAME" ] || git clone --branch $_GIT_BRANCH $_GIT_REPO
```

## Test plan
- Build process should work identically
- Guard clause still prevents re-cloning if directory exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)