### PR TITLE
Configure renovate to use all ubuntu suites for packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,33 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
+      "matchStrings": [
+        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
+      ],
+      "datasourceTemplate": "deb",
+      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-security&components=main,universe,restricted,multiverse&binaryArch=amd64"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
+      "matchStrings": [
+        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
+      ],
+      "datasourceTemplate": "deb",
+      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-updates&components=main,universe,restricted,multiverse&binaryArch=amd64"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
+      "matchStrings": [
+        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
+      ],
+      "datasourceTemplate": "deb",
+      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-backports&components=main,universe,restricted,multiverse&binaryArch=amd64"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
       "matchStrings": ["ARG HADOLINT_VERSION=(?<currentValue>\\S+)"],
       "depNameTemplate": "hadolint/hadolint",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
## Summary
Configure Renovate to check all Ubuntu suites (noble-security, noble-updates, noble-backports, noble) instead of just the base release suite.

This ensures Renovate can detect security updates and post-release updates that are published to `-security` and `-updates` pockets.

## Changes
- Split single Ubuntu deb custom manager into four separate managers
- Each manager checks a different Ubuntu suite: noble, noble-security, noble-updates, noble-backports
- Renovate will now detect the highest version across all suites

## Context
Previously, when security updates like gnupg 2.4.4-2ubuntu17.4 were published to noble-security and noble-updates, Renovate couldn't detect them because it only checked the base noble suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)