### PR TITLE
Remove build container after run

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ EOM
 
 curl -v -sS -w '\n%{http_code}' \
   --data-binary "$JSON_BODY" \
-  "https://api.conjob.io/job/run?image=$IMAGE_NAME" \
+  "https://api.conjob.io/job/run?image=$IMAGE_NAME&remove=true" \
   | tee /tmp/foo \
   | sed '$d' && \
   [ "$(tail -1 /tmp/foo)" -eq 200 ]


### PR DESCRIPTION
Keeping these containers around indefinitely uses up too much disk space. We already have the logs in github and we rarely if ever need the container around for any purpose like debugging.

Adds `&remove=true` to the conjob API call in build.sh.