### PR TITLE
Run PR workflow when changes pushed to any non-master branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,8 +2,8 @@ name: PR CI
 
 on:
   push:
-    branches:
-      - 'renovate/**'
+    branches-ignore:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Change PR CI workflow trigger from `branches: ['renovate/**']` to `branches-ignore: [master]` so that CI builds run for all non-master branches, not just renovate changes.